### PR TITLE
Configure CORS origins for development

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
+
+import os
 import traceback
+
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
@@ -7,13 +10,19 @@ from .converters import docx_to_markdown_and_html
 
 app = FastAPI(title="LavaTools", version="0.1.0")
 
-from fastapi.middleware.cors import CORSMiddleware
+_allowed_origins = os.getenv("ALLOWED_ORIGINS")
+if _allowed_origins:
+    allow_origins = [origin.strip() for origin in _allowed_origins.split(",") if origin.strip()]
+else:
+    allow_origins = [
+        "https://lavatools-web.fly.dev",  # frontend prod
+        "http://localhost:5173",  # local dev
+        "http://127.0.0.1:5173",  # local dev loopback
+    ]
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "https://lavatools-web.fly.dev",  # frontend prod
-    ],
+    allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- allow configuring CORS origins via the ALLOWED_ORIGINS environment variable
- include local development URLs in the default allowed origins list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd2f821e748327803c00769b78c2cf