### PR TITLE
Add WordPress subscriptions fetch endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
+
 import traceback
-from fastapi import FastAPI, UploadFile, File, HTTPException
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+
 from .converters import docx_to_markdown_and_html
+from .wordpress_client import (
+    WordPressAuthenticationError,
+    WordPressClient,
+    fetch_subscriptions_page,
+)
 
 app = FastAPI(title="LavaTools", version="0.1.0")
-
-from fastapi.middleware.cors import CORSMiddleware
 
 app.add_middleware(
     CORSMiddleware,
@@ -26,12 +32,26 @@ class ConvertResponse(BaseModel):
     engine: str
     stats: dict
 
+
+class WordPressSubscriptionsRequest(BaseModel):
+    base_url: str
+    username: str
+    password: str
+
+
+class WordPressSubscriptionsResponse(BaseModel):
+    base_url: str
+    admin_path: str
+    html: str
+
+
 @app.get("/health")
-def health():
+def health() -> dict:
     return {"status": "ok"}
 
+
 @app.post("/convert", response_model=ConvertResponse)
-async def convert(file: UploadFile = File(...)):
+async def convert(file: UploadFile = File(...)) -> ConvertResponse:
     if not file.filename.lower().endswith(".docx"):
         raise HTTPException(400, detail="Merci d'envoyer un fichier .docx")
 
@@ -41,9 +61,9 @@ async def convert(file: UploadFile = File(...)):
 
     try:
         md, html, engine = docx_to_markdown_and_html(data)
-    except Exception as e:
+    except Exception as exc:  # pragma: no cover - defensive guard
         traceback.print_exc()  # utile en dev pour voir la stack dans les logs
-        raise HTTPException(500, detail=f"Conversion échouée: {e}")
+        raise HTTPException(500, detail=f"Conversion échouée: {exc}") from exc
 
     stats = {
         "bytes": len(data),
@@ -52,3 +72,35 @@ async def convert(file: UploadFile = File(...)):
         "engine": engine,
     }
     return ConvertResponse(markdown=md, html=html, engine=engine, stats=stats)
+
+
+@app.post(
+    "/wordpress/subscriptions",
+    response_model=WordPressSubscriptionsResponse,
+    summary="Fetch the WooCommerce subscriptions admin page HTML.",
+)
+async def wordpress_subscriptions(
+    payload: WordPressSubscriptionsRequest,
+) -> WordPressSubscriptionsResponse:
+    """Authenticate against WordPress and return the subscriptions page HTML."""
+
+    client = WordPressClient(payload.base_url)
+
+    try:
+        html = fetch_subscriptions_page(
+            base_url=client.base_url,
+            username=payload.username,
+            password=payload.password,
+            client=client,
+        )
+    except WordPressAuthenticationError as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+    subscriptions_path = (
+        "wp-admin/admin.php?page=wf_subscriptions_csv_im_ex&tab=subscriptions"
+    )
+    return WordPressSubscriptionsResponse(
+        base_url=client.base_url,
+        admin_path=subscriptions_path,
+        html=html,
+    )

--- a/app/wordpress_client.py
+++ b/app/wordpress_client.py
@@ -151,7 +151,12 @@ class WordPressClient:
         return response.text
 
 
-def fetch_subscriptions_page(base_url: str, username: str, password: str) -> str:
+def fetch_subscriptions_page(
+    base_url: str,
+    username: str,
+    password: str,
+    client: Optional[WordPressClient] = None,
+) -> str:
     """Convenience helper that logs in and returns the WooCommerce page HTML.
 
     This helper is tailored for the "WooCommerce → Import Export Suite →
@@ -160,7 +165,9 @@ def fetch_subscriptions_page(base_url: str, username: str, password: str) -> str
     Import Export Suite.
     """
 
-    client = WordPressClient(base_url)
+    if client is None:
+        client = WordPressClient(base_url)
+
     client.login(username, password)
 
     subscriptions_path = (


### PR DESCRIPTION
## Summary
- add FastAPI models and endpoint for retrieving the WooCommerce subscriptions admin page
- surface WordPress authentication failures as 401 responses for the frontend
- allow reusing an existing `WordPressClient` when fetching the subscriptions page

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dd2f8d35048327af92054c22c71bee