### PR TITLE
Normalize WordPress base URLs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -282,10 +282,22 @@ def _normalise_base_url(raw_url: str) -> str:
             "L'URL fournie n'est pas valide. Exemple attendu: https://monsite.com"
         )
 
-    if not raw_url.endswith("/"):
-        raw_url = f"{raw_url}/"
+    path = parsed.path or "/"
+    lowered = path.lower()
 
-    return raw_url
+    admin_markers = ("/wp-admin", "/wp-login.php")
+    for marker in admin_markers:
+        idx = lowered.find(marker)
+        if idx != -1:
+            path = path[:idx] or "/"
+            lowered = path.lower()
+            break
+
+    if not path.endswith("/"):
+        path = f"{path}/"
+
+    normalised = parsed._replace(path=path, params="", query="", fragment="")
+    return normalised.geturl()
 
 
 def _wordpress_error(status_code: int, message: str) -> JSONResponse:

--- a/tests/test_normalise_base_url.py
+++ b/tests/test_normalise_base_url.py
@@ -1,0 +1,65 @@
+import sys
+import types
+import unittest
+
+
+def _ensure_playwright_stub() -> None:
+    if "playwright" in sys.modules and "playwright.sync_api" in sys.modules:
+        return
+
+    sync_api = types.ModuleType("playwright.sync_api")
+    sync_api.Error = Exception
+    sync_api.Locator = object
+    sync_api.Page = object
+    sync_api.TimeoutError = TimeoutError
+    sync_api.sync_playwright = lambda: (_ for _ in ()).throw(RuntimeError("stub"))
+
+    playwright = types.ModuleType("playwright")
+    sys.modules["playwright"] = playwright
+    sys.modules["playwright.sync_api"] = sync_api
+
+
+class NormaliseBaseURLTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        _ensure_playwright_stub()
+        from app.main import _normalise_base_url  # type: ignore
+
+        self._normalise = _normalise_base_url
+
+    def test_basic_domain(self) -> None:
+        self.assertEqual(self._normalise("https://example.com"), "https://example.com/")
+
+    def test_trailing_slash_preserved(self) -> None:
+        self.assertEqual(self._normalise("https://example.com/"), "https://example.com/")
+
+    def test_removes_wp_admin_suffix(self) -> None:
+        self.assertEqual(self._normalise("https://example.com/wp-admin"), "https://example.com/")
+        self.assertEqual(self._normalise("https://example.com/wp-admin/"), "https://example.com/")
+
+    def test_removes_login_suffix(self) -> None:
+        self.assertEqual(
+            self._normalise("https://example.com/wp-login.php"), "https://example.com/"
+        )
+
+    def test_preserves_subdirectory(self) -> None:
+        self.assertEqual(
+            self._normalise("https://example.com/blog"),
+            "https://example.com/blog/",
+        )
+        self.assertEqual(
+            self._normalise("https://example.com/blog/wp-admin"),
+            "https://example.com/blog/",
+        )
+
+    def test_strips_query_and_fragment(self) -> None:
+        self.assertEqual(
+            self._normalise("https://example.com/wp-admin/?foo=bar#baz"),
+            "https://example.com/",
+        )
+
+    def test_infers_scheme(self) -> None:
+        self.assertEqual(self._normalise("example.com/wp-admin"), "https://example.com/")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- strip wp-admin/wp-login suffixes, query parameters and fragments from submitted WordPress URLs to build stable admin links
- add unit tests covering the base URL normalisation helper and a Playwright stub for import safety

## Testing
- PYTHONPATH=. python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68dda31d3d148327bc4064a07ca552aa