### PR TITLE
Install Chromium dependencies for Selenium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,29 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Déps système: pandoc pour une conversion top (optionnel mais utile)
-RUN apt-get update && apt-get install -y --no-install-recommends pandoc \
+# + bibliothèques nécessaires pour les navigateurs headless Chromium/Chrome.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        pandoc \
+        chromium \
+        chromium-driver \
+        fonts-liberation \
+        libasound2 \
+        libatk1.0-0 \
+        libcairo2 \
+        libdrm2 \
+        libgbm1 \
+        libgtk-3-0 \
+        libnss3 \
+        libxkbcommon0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Déps Python
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Télécharge les binaires Playwright/Selenium nécessaires pour les exports.
+RUN playwright install chromium
 
 # Code de l'app
 COPY app ./app


### PR DESCRIPTION
## Summary
- add chromium, chromedriver and supporting libraries to the image build so Selenium can launch the browser in production
- pre-install the Playwright chromium bundle to avoid missing browser binaries at runtime

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68e0eccddbec8327852b13e8e1add1ce