### PR TITLE
Add Playwright dependency for Docker builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ selenium>=4.24
 python-multipart>=0.0.9   # nécessaire pour UploadFile / form-data
 mammoth>=1.8.0            # conversion DOCX -> HTML
 markdownify>=0.12.1       # HTML -> Markdown
+playwright>=1.44          # navigateur headless pour les exports


### PR DESCRIPTION
## Summary
- add Playwright to the Python requirements so the Docker build can run `playwright install`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1007611788327a170ce83698a4ad2