### PR TITLE
Update Docker port configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ RUN playwright install chromium
 # Code de l'app
 COPY app ./app
 
-EXPOSE 8000
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+EXPOSE 8080
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080}"]


### PR DESCRIPTION
## Summary
- update the Docker image to listen on the platform-provided port so Fly.io health checks succeed

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68e106524dec8327aaca4a5f717023dc