### PR TITLE
Reduce Fly deployment resource allocation

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -12,9 +12,10 @@ primary_region = "ams"
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = false
+  auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
+  max_machines_running = 1
   processes = ["app"]
 
   [http_service.concurrency]
@@ -30,6 +31,6 @@ primary_region = "ams"
     path = "/health"
 
 [[vm]]
-  memory = "1gb"
+  memory = "256mb"
   cpu_kind = "shared"
   cpus = 1


### PR DESCRIPTION
## Summary
- limit the Fly Machines deployment to a single running instance
- downgrade the machine memory allocation to the 256 MB minimum to reduce resource usage

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e8d7654efc8322b133d68f68f0691e